### PR TITLE
Add php-7.4 version on Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,14 +18,17 @@ matrix:
       env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_DEPRECATIONS_HELPER="max[self]=0"
     - php: 7.3
       env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_DEPRECATIONS_HELPER="max[self]=0"
+    - php: 7.4
+      env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_DEPRECATIONS_HELPER="max[self]=0"
 
       # Test the latest stable release
     - php: 7.2
     - php: 7.3
+    - php: 7.4
       env: COVERAGE=true PHPUNIT_FLAGS="-v --coverage-text --coverage-clover=coverage.xml"
 
       # Latest commit to master
-    - php: 7.3
+    - php: 7.4
       env: STABILITY="dev"
 
   allow_failures:

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     }
   ],
   "require": {
-    "php": "^7.1.3",
+    "php": "^7.2",
     "ext-json": "*",
     "league/fractal": "^0.18.0",
     "symfony/http-foundation": "^4.3",

--- a/tests/Unit/ResponseFactoryTest.php
+++ b/tests/Unit/ResponseFactoryTest.php
@@ -28,7 +28,7 @@ class ResponseFactoryTest extends TestCase
      */
     private $fractal;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->fractal = $this->getMockBuilder(Manager::class)
         ->disableOriginalConstructor()


### PR DESCRIPTION
# Changed log
- Add `php-7.4` version on Travis CI build.
- Let this package require `php-7.2` version at least.
- Let `setUp` method have the `void` type hint to be compatible with `PHPUnit` fixture methods.